### PR TITLE
[PDD-350] Set auth refresh parameter to false

### DIFF
--- a/tap_superset/auth.py
+++ b/tap_superset/auth.py
@@ -18,7 +18,7 @@ def fetch_token(base_url, username, password):
 
     json_data = {
         "provider": "db",
-        "refresh": True,
+        "refresh": False,
         "username": username,
         "password": password,
     }


### PR DESCRIPTION
This should prevent the token from auto-refreshing during extraction